### PR TITLE
修复了当外部PK与本地FK名称不一样时，无法FillReference的问题。

### DIFF
--- a/Core/SQL Store Base/SQLStoreBase.cs
+++ b/Core/SQL Store Base/SQLStoreBase.cs
@@ -1580,7 +1580,7 @@ namespace OpenNETCF.ORM
                     {
                         // In a N:1 relation, the local ('instance' coming in here) key is the FK and the remote it the PK.  
                         // We need to read the local FK, so we can go to the reference table and pull the one row with that PK value
-                        keyValue = m_entities[entityName].Fields[reference.ForeignReferenceField].PropertyInfo.GetValue(instance, null);
+                        keyValue = m_entities[entityName].Fields[reference.LocalReferenceField].PropertyInfo.GetValue(instance, null);
                     }
 
                     // get the lookup values - until we support filtered selects, this may be very expensive memory-wise


### PR DESCRIPTION
In a N:1 relation, we should read the LocalReferenceField insdead of the ForeignReferenceField.
or else if the reference table's PK name is not equals with the local FK name, the FillReference doen't work.